### PR TITLE
Removed dependance on time reference from gps enabled chips 

### DIFF
--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,0 +1,16 @@
+<launch>
+	<arg name="namespace" default="example"/>
+	<arg name="wit_input" default="/dev/ttyUSB0"/>
+	<arg name="wit_input_speed" default="115200" />
+	
+	<group ns="$(arg namespace)">
+		<group ns="sensors">
+			<node pkg="witmotion" type="witmotion_node.py" name="witmotion">
+				<param name="frame_id" value="$(arg namespace)/motion_sensor"/>
+				<param name="port" value="$(arg wit_input)"/>
+				<param name="baud" value="$(arg wit_input_speed)"/>
+			</node>
+	
+		</group>
+	</group>
+</launch>

--- a/nodes/witmotion_node.py
+++ b/nodes/witmotion_node.py
@@ -7,13 +7,14 @@ from sensor_msgs.msg import NavSatStatus
 from sensor_msgs.msg import Imu
 from sensor_msgs.msg import TimeReference
 from geometry_msgs.msg import TwistStamped
+from sensor_msgs.msg import MagneticField
 
 import math
 
 rospy.init_node('witmotion')
 
 port = rospy.get_param('~port', '/dev/ttyUSB0')
-baud = rospy.get_param('~baud', 9600)
+baud = rospy.get_param('~baud', 115200)
     
 frame_id = rospy.get_param('~frame_id', 'witmotion')
     
@@ -21,6 +22,7 @@ position_pub = rospy.Publisher('~position',NavSatFix,queue_size=10)
 timeref_pub = rospy.Publisher('~time_reference',TimeReference,queue_size=10)
 orientation_pub = rospy.Publisher('~orientation',Imu,queue_size=10)
 velocity_pub = rospy.Publisher('~velocity',TwistStamped,queue_size=10)
+magnetic_pub = rospy.Publisher('~magnetic',MagneticField,queue_size=10)
 
 wm = witmotion.Witmotion(port, baud)    
 
@@ -32,67 +34,81 @@ while not rospy.is_shutdown():
         now = rospy.get_rostime()
         for d in data:
             # time
-            #print (d)
             if 'timestamp' in d:
-                sensor_time = rospy.Time.from_sec(d['timestamp'].timestamp())
+                now = rospy.Time.from_sec(d['timestamp'].timestamp())
                 tref = TimeReference()
                 tref.header.stamp = now
-                tref.time_ref = sensor_time
+                tref.time_ref = now
                 tref.source = frame_id
                 timeref_pub.publish(tref)
 
-                if 'satellite_count' in d:
-                    navsat_status = NavSatStatus()
-                    navsat_status.service = NavSatStatus.SERVICE_GPS
-                    navsat_status.status = NavSatStatus.STATUS_NO_FIX
-            
-                    if d['satellite_count'] > 2:
-                        navsat_status.status = NavSatStatus.STATUS_FIX
-
-                        try:
-                            nsf = NavSatFix()
-                            nsf.status = navsat_status
-                            nsf.header.stamp = sensor_time
-                            nsf.header.frame_id = frame_id
-                            nsf.latitude = d['latitude']
-                            nsf.longitude = d['longitude']
-                            nsf.altitude = d['gps_height']
-                            position_pub.publish(nsf)
-                        except KeyError:
-                            pass
-            
-                if 'quaternion' in d:
+            if 'satellite_count' in d:
+                navsat_status = NavSatStatus()
+                navsat_status.service = NavSatStatus.SERVICE_GPS
+                navsat_status.status = NavSatStatus.STATUS_NO_FIX
+        
+                if d['satellite_count'] > 2:
+                    navsat_status.status = NavSatStatus.STATUS_FIX
 
                     try:
-
-                        imu = Imu()                  
-                        imu.header.stamp = sensor_time
-                        imu.header.frame_id = frame_id
-                        
-                        imu.orientation.x = d['quaternion'][0]
-                        imu.orientation.y = d['quaternion'][1]
-                        imu.orientation.z = d['quaternion'][2]
-                        imu.orientation.w = d['quaternion'][3]
-                        imu.angular_velocity.x = math.radians(d['angular_velocity'][0])
-                        imu.angular_velocity.y = math.radians(d['angular_velocity'][1])
-                        imu.angular_velocity.z = math.radians(d['angular_velocity'][2])
-                        imu.linear_acceleration.x = d['acceleration'][0]
-                        imu.linear_acceleration.y = d['acceleration'][1]
-                        imu.linear_acceleration.z = d['acceleration'][2]
-                        
-
-                        orientation_pub.publish(imu)
-
-                        ts = TwistStamped()
-                        ts.header.stamp = sensor_time
-                        ts.header.frame_id = frame_id
-                        yaw_rad = math.radians(d['course'])
-                        ts.twist.linear.x = d['speed']*math.cos(yaw_rad)
-                        ts.twist.linear.y = d['speed']*math.sin(yaw_rad)
-                        
-                        ts.twist.angular = imu.angular_velocity
-                        velocity_pub.publish(ts)
+                        nsf = NavSatFix()
+                        nsf.status = navsat_status
+                        nsf.header.stamp = now
+                        nsf.header.frame_id = frame_id
+                        nsf.latitude = d['latitude']
+                        nsf.longitude = d['longitude']
+                        nsf.altitude = d['gps_height']
+                        position_pub.publish(nsf)
                     except KeyError:
                         pass
+        
+            if 'quaternion' in d:
+
+                try:
+
+                    imu = Imu()                  
+                    imu.header.stamp = now
+                    imu.header.frame_id = frame_id
+                    
+                    imu.orientation.x = d['quaternion'][0]
+                    imu.orientation.y = d['quaternion'][1]
+                    imu.orientation.z = d['quaternion'][2]
+                    imu.orientation.w = d['quaternion'][3]
+                    imu.angular_velocity.x = math.radians(d['angular_velocity'][0])
+                    imu.angular_velocity.y = math.radians(d['angular_velocity'][1])
+                    imu.angular_velocity.z = math.radians(d['angular_velocity'][2])
+                    imu.linear_acceleration.x = d['acceleration'][0]
+                    imu.linear_acceleration.y = d['acceleration'][1]
+                    imu.linear_acceleration.z = d['acceleration'][2]
+                    
+
+                    orientation_pub.publish(imu)
+
+                    ts = TwistStamped()
+                    ts.header.stamp = now
+                    ts.header.frame_id = frame_id
+                    yaw_rad = math.radians(d['course'])
+                    ts.twist.linear.x = d['speed']*math.cos(yaw_rad)
+                    ts.twist.linear.y = d['speed']*math.sin(yaw_rad)
+                    
+                    ts.twist.angular = imu.angular_velocity
+                    velocity_pub.publish(ts)
+
+                except KeyError:
+                    pass
+
+            if 'magnetic' in d:
+                try:
+
+                    mag = MagneticField()
+                    mag.header.stamp = now
+                    mag.header.frame_id = frame_id
+                    mag.magnetic_field.x = d['magnetic'][0]
+                    mag.magnetic_field.y = d['magnetic'][1]
+                    mag.magnetic_field.z = d['magnetic'][2]
+                    magnetic_pub.publish(mag)
+
+                except KeyError:
+                    pass
 
 

--- a/src/witmotion/witmotion.py
+++ b/src/witmotion/witmotion.py
@@ -6,7 +6,7 @@ import struct
 import datetime
 
 class Witmotion:
-    def __init__(self, port='/dev/ttyUSB0', baud=9600):
+    def __init__(self, port='/dev/ttyUSB0', baud=115200):
         self.port = serial.Serial(port, baud, timeout=0.01)
         self.buffer = None
         self.pending_record = {}
@@ -29,12 +29,13 @@ class Witmotion:
                 data = self.pending_record
                 while len(self.buffer) >= 11:
 
-                    msg = self.buffer[:11]
+                    msg = self.buffer[:11]  
                     sum = 0
                     for i in range(10):
                         sum = (sum+msg[i])&0xff
                     if sum != msg[10]:
                         # invalid packet
+                        # print('invalid packet')
                         self.buffer = self.buffer[1:]
                     else:
                         self.buffer = self.buffer[11:]
@@ -103,9 +104,9 @@ class Witmotion:
                                 data['vdop'] = vdop/32768.0
                         except ValueError:
                             data = {}
-
+                ret.append(data)
+                data = {}
                 self.pending_record = data
-
                 if len(self.buffer) == 0:
                     self.buffer = None
                 if len(ret) > 0:


### PR DESCRIPTION
This pr has three main changes, for one, it adds and example launch file. It also changes when data read from the serial port gets returned to the ros driver. previously data would only get returned to the ros driver when a timestamp message was present. Next it also removes the dependence on a hardware time reference in the ros driver, the code will now publish data to the relevant topics with rospy.now() when a timestamp isn't present, and if there is a timestamp present, it will use it as the header time. Finally this change also adds decoding of magnetic messages in the ros driver. 